### PR TITLE
#17 投稿の保存(2024.2.12)

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -30,8 +30,26 @@ class PostController extends Controller
      */
     public function store(Request $request)
     {
-        //
+      $inputs = $request->validate([
+      'title' => 'required|max:255',
+      'body' => 'required|max:2000',
+      'image' => 'image|max:2000',
+      ]);
+      $post = new Post(); //postモデルに準じてpostのインスタンスを作成
+      $post->title = $request->title;
+      $post->body = $request->body;
+      $post->user_id = auth()->user()->id;
+
+      if(request('image')) {  //もし送信されたデータの中にimageがあれば、次の処理を行う↓↓
+        $original = request()->file('image')->getClientOriginalName(); //元々のファイル名を取得し、これを$originalに代入する
+        $name = date('Ymd_His').'_'.$original;  //秒まで表示する日付を表示させ、$nameの名前で画像ファイルを指定した場所に保存する
+        request()->file('image')->move('storage/images',$name);  //$nameの名前で画像ファイルのファイル名をデータベースに保存する
+        $post->image = $name;
+      }
+      $post->save();
+      return redirect()->route('top',$post)->with('message','投稿を送信しました');
     }
+      
 
     /**
      * Display the specified resource.

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -9,6 +9,12 @@ class Post extends Model
 {
     use HasFactory;
 
+    protected $fillable=[
+      'title',
+      'body',
+      'user_id',
+    ];
+
     public function user() {
       return $this->belongsTo(User::class);
     }

--- a/app/View/Components/Message.php
+++ b/app/View/Components/Message.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class Message extends Component
+{
+    public $message;
+    /**
+     * Create a new component instance.
+     */
+    public function __construct($message)
+    {
+      $this->message = $message;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('components.message');
+    }
+}

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -116,6 +116,10 @@ return [
     |
     */
 
-    'attributes' => [],
+    'attributes' => [
+      'title' => '件名',
+      'body' => '本文',
+      'image' => '画像',
+    ],
 
 ];

--- a/resources/views/commons/error_messages.blade.php
+++ b/resources/views/commons/error_messages.blade.php
@@ -4,6 +4,9 @@
     @foreach($errors->all() as $error)
      <li class="ml-4">{{$error}}</li>
     @endforeach
+    @if(empty($errors->first('image')))
+     <li>画像ファイルがある場合、再度選択してください</li>
+    @endif
   </ul>
  </div>
 @endif

--- a/resources/views/components/message.blade.php
+++ b/resources/views/components/message.blade.php
@@ -1,0 +1,6 @@
+<div>
+ @if(isset($message))
+  <div class="border px-4 py-3 rounded relative bg-green-100 border-green-400 text-green-700">
+   {{$message}}
+  </div>
+ @endif


### PR DESCRIPTION
## issue
- Close #17
## 概要
- 投稿の保存機能
## 動作確認手順
- PostControllerにstoreメソッドを実装
- Postモデルに$fillableを追加(タイトル・本文・ユーザーID)
- バリデーションメッセージの日本語化(追加：件名・本文・画像)
- 補足としてComponentsファイルを作成(エラーメッセージの装飾)
- シンボリックリンク(public->storage)を作成
- バリデーションエラーの際、画像に関するメッセージを追加
## 考慮してほしい事
- showメソッドが未実装のため、phpMyAdminで投稿や画像が正しく保存されているか確認が必要です
## 確認してほしい事
- phpMyAdminにて投稿や画像が正しく保存されているかご確認お願いします。