### PR TITLE
#20 投稿更新の保存(2024.2.17)

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -77,7 +77,22 @@ class PostController extends Controller
      */
     public function update(Request $request, Post $post)
     {
-        //
+       $inputs = $request->validate([
+          'title' => 'required|max:255',
+          'body' => 'required|max:2000',
+          'image' => 'image|max:2000',
+       ]);
+       $post->title = $inputs['title'];
+       $post->body = $inputs['body'];
+
+       if(request('image')) {
+        $original =request()->file('image')->getClientOriginalName();
+        $name = date('Ymd_His').'_'.$original;
+        $file = request()->file('image')->move('storage/images',$name);
+        $post->image = $name;
+       }
+       $post->save();
+       return redirect()->route('post.show',$post)->with('message','投稿を更新しました');
     }
 
     /**

--- a/resources/views/post/edit.blade.php
+++ b/resources/views/post/edit.blade.php
@@ -11,7 +11,7 @@
           <h2>投稿の編集</h2>
           <p>↓↓投稿内容を編集後、更新ボタンを押してください↓↓</p>
         </div>
-          <form action="{{route('post.edit',$post)}}" method="post" enctype="multipart/form-data">
+          <form action="{{route('post.update',$post)}}" method="post" enctype="multipart/form-data">
             @csrf
             @method('put')
              <div class="form-group">
@@ -20,7 +20,7 @@
              </div>
              <div class="form-group">
                <label for="body">本文</label>
-               <textarea name="text" id="body" name="body" cols="30" rows="10" required>{{old('body',$post->body)}}</textarea>
+               <textarea id="body" name="body" cols="30" rows="10" required>{{old('body',$post->body)}}</textarea>
              </div>
              <div class="form-group">
                @if($post->image)

--- a/resources/views/post/show.blade.php
+++ b/resources/views/post/show.blade.php
@@ -26,7 +26,7 @@
  </a>
  @endif
  @if(Auth::check() && (Auth::id() === $post->user_id || Auth::user()->isAdmin()))
-  <form action="{{ route('post.destroy',$post) }}" method="post">
+  {{-- <form action="{{ route('post.destroy',$post) }}" method="post"> --}}
   @csrf
   @method('delete')
    <div class="edit-button-container">

--- a/resources/views/post/show.blade.php
+++ b/resources/views/post/show.blade.php
@@ -26,7 +26,7 @@
  </a>
  @endif
  @if(Auth::check() && (Auth::id() === $post->user_id || Auth::user()->isAdmin()))
-  {{-- <form action="{{ route('post.destroy',$post) }}" method="post"> --}}
+  <form action="{{ route('post.destroy',$post) }}" method="post">
   @csrf
   @method('delete')
    <div class="edit-button-container">

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,7 +40,8 @@ Route::get('post',[PostController::class,'index'])->name('post.index'); //投稿
 Route::get('post/create',[PostController::class,'create'])->name('post.create'); //新規投稿表示
 Route::post('post',[PostController::class,'store'])->name('post.store'); //新規投稿実行
 Route::get('post/{post}',[PostController::class,'show'])->name('post.show'); //投稿個別表示
-Route::get('post/{post}/edit',[PostController::class,'edit'])->name('post.edit'); //投稿の更新
+Route::get('post/{post}/edit',[PostController::class,'edit'])->name('post.edit'); //投稿の更新(編集画面表示)
+Route::put('post/{post}',[PostController::class,'update'])->name('post.update'); //更新を保存
 
 //新規登録
 Route::get('signup',[RegisterController::class,'showRegistrationForm'])->name('signup'); //新規登録表示


### PR DESCRIPTION
## issue
- Close #20
## 概要
- 投稿更新の保存機能の実装
## 動作確認手順
- 投稿更新画面で投稿の更新を行い、更新ボタンをクリックし正しく投稿が更新するか確認
## 考慮してほしい事
- destroyメソッドが未実装のため、show.blade.phpの<form action="{{ route('post.destroy',$post) }}" method="post">をコメントアウトして動作確認が必要です  
## 確認してほしい事
- 投稿更新の保存が正しく行えるかご確認よろしくお願いいたします。

