### PR TITLE
#24 自分の返信コメント表示(2024.2.25)

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Post;
 use App\Models\User;
+use App\Models\Comment;
 use Illuminate\Http\Request;
 class PostController extends Controller
 {
@@ -109,5 +110,11 @@ class PostController extends Controller
       $user = auth()->user()->id;
       $posts = Post::where('user_id',$user)->orderBy('created_at','desc')->get();
       return view('post.mypost',['posts' => $posts]);
+    }
+
+    public function mycomment() {
+      $user = auth()->user()->id;
+      $comments = Comment::where('user_id',$user)->orderBy('created_at','desc')->get();
+      return view('post.mycomment',['comments' => $comments]);
     }
 }

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -8,7 +8,7 @@
         <ul>
             <li><a href="{{route('logout')}}">ログアウト</a></li>
             <li><a href="{{route('post.mypost')}}">あなたの投稿一覧</a></li>
-            <li><a href="#">あなたの返信コメント</a></li>
+            <li><a href="{{route('post.mycomment')}}">あなたの返信コメント</a></li>
             <li><a href="#">お問い合わせ</a></li>
         </ul>
        @else

--- a/resources/views/post/mycomment.blade.php
+++ b/resources/views/post/mycomment.blade.php
@@ -1,0 +1,49 @@
+@extends('layouts.app')
+ @section('content')
+  <div class="mycomment-name-container">
+    <p>{{auth()->user()->name}}さん、こんにちは！</p>
+    <h1>あなたの返信コメント一覧</h1>
+  </div>
+    @include('commons.success_message')
+     @if(count($comments) == 0)
+      <p>あなたはまだ返信コメントを投稿していません</p>
+      @else
+       @foreach($comments->unique('post_id') as $comment) {{-- 同じpost_idのコメントは最初の一回だけ表示させる --}}
+        @php
+          $post = $comment->post; //$postをコメント投稿として置き換える
+        @endphp
+          <div class="mycomment-container">
+            <div class="title-container">
+              <a href="{{route('post.show',$post)}}">
+                <p>件名:{{$post->title}}</p>
+              </a>
+            </div>
+              <div class="body-container">
+                  <p>投稿内容:{{Str::limit($post->body,100,'...')}}</p>
+              </div>
+                <div class="comment-badge-container">
+                   @if($post->comments->count())
+                     <span class="badge">
+                        コメント{{$post->comments->count()}}件
+                     </span>
+                    @else
+                     <p>
+                        コメントはまだありません
+                     </p>
+                    @endif
+                </div>
+                  <a href="{{route('post.show',$post)}}">
+                     <div class="button-container">
+                        <button type="submit" class="btn btn-success">コメントする</button>
+                     </div>
+                  </a>
+                </div>
+       @endforeach
+      @endif
+      <div class="mypost-link">
+          <a href="{{route('post.mypost')}}">
+            あなたの投稿はこちら
+          </a>
+      </div>
+      @include('commons.return_back')
+ @endsection

--- a/resources/views/post/mypost.blade.php
+++ b/resources/views/post/mypost.blade.php
@@ -38,6 +38,11 @@
        </div>
      @endforeach
     @endif
-     @include('commons.return_back')
+    <div class="mycomment-link">
+       <a href="{{route('post.mycomment')}}">
+        あなたの返信コメントはこちら
+       </a>
+    </div>
+    @include('commons.return_back')
  @endsection
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,6 +39,8 @@ Route::get('/home', [App\Http\Controllers\HomeController::class, 'index'])->name
 
 //自分の投稿のみ表示
 Route::get('post/mypost',[PostController::class,'mypost'])->name('post.mypost');
+//自分の返信コメントのみ表示
+Route::get('post/mycomment',[PostController::class,'mycomment'])->name('post.mycomment');
 
 Route::get('/',[PostController::class,'index'])->name('post.index'); //投稿一覧ページ
 Route::get('post/create',[PostController::class,'create'])->name('post.create'); //新規投稿表示


### PR DESCRIPTION
## issue
- Close #24
## 概要
- 自分の返信コメントの表示実装
## 動作確認手順
- 会員登録後、あるいはログイン後に｢あなたの返信コメント｣をクリックすると返信コメント一覧が表示されるか確認
- 返信コメントがない場合、｢返信コメントはありません｣、返信コメントがある場合は一覧が表示されるか確認
- 返信の編集と削除ボタンが表示されているか確認
## 考慮してほしい事
- 返信コメント以外の修正を行いました(mypost.blade.phpファイルにmycomment.blade.phpのリンクを作成 )
## 確認してほしい事
- ログイン後のメニューにある｢あなたの返信コメント｣にクリックすると正しく一覧画面が表示されるかご確認よろしくお願いいたします。
- 返信コメントの削除・編集ボタンが正常に表示されるかご確認よろしくお願いいたします。
