### PR TITLE
#27 動作の制限(gate)2024.3.3

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace App\Providers;
 
-// use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -21,6 +21,13 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+       Gate::define('admin',function($user) {
+        foreach($user->roles as $role) {
+          if($role->name == 'admin') {
+            return true;
+          }
+        }
+        return false;
+       });
     }
 }

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -9,7 +9,10 @@
             <li><a href="{{route('logout')}}">ログアウト</a></li>
             <li><a href="{{route('post.mypost')}}">あなたの投稿一覧</a></li>
             <li><a href="{{route('post.mycomment')}}">あなたの返信コメント</a></li>
+            {{-- admin(管理者)ユーザー以外は表示されないようにする --}}
+            @can('admin')   
             <li><a href="{{route('profile.index')}}">ユーザー一覧(管理者専用)</a></li>
+            @endcan
         </ul>
        @else
         <ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,12 +22,15 @@ Route::get('/', function () {
     return view('welcome');
 })->name('top');
 
-Route::get('/dashboard', function () {
-    return view('dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+// Route::get('/dashboard', function () {
+//     return view('dashboard');
+// })->middleware(['auth', 'verified'])->name('dashboard');
+
+Route::middleware(['auth','can:admin'])->group(function(){
+    Route::get('/profile/index', [ProfileController::class, 'index'])->name('profile.index');
+});
 
 Route::middleware('auth')->group(function () {
-    Route::get('/profile/index', [ProfileController::class, 'index'])->name('profile.index');
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
@@ -64,6 +67,6 @@ Route::get('login',[LoginController::class,'showLoginForm'])->name('login'); //�
 Route::post('login',[LoginController::class,'login'])->name('login.post'); //ログイン実行
 Route::get('logout',[LoginController::class,'logout'])->name('logout'); //ログアウト実行
 //お問い合わせ機能
-Route::get('contact/create',[ContactController::class,'create'])->name('contact.create'); //お問い合わせ表示
+Route::get('contact/create',[ContactController::class,'create'])->name('contact.create')->middleware('guest'); //お問い合わせ表示
 Route::post('contact/store',[ContactController::class,'store'])->name('contact.store'); //お問い合わせ保存
 


### PR DESCRIPTION
## issue
- Close #27
## 概要
- 動作の制限(Gate)の実装
## 動作確認手順
- 管理者(admin)がログイン後、メニューに｢ユーザー一覧(管理者専用)｣が表示されることを確認
- 一般ユーザー(user)がログイン後には｢ユーザー一覧(管理者専用)｣のメニューが表示されないことを確認
- 一般ユーザーがログイン後にurlに直接http://localhost:8000/profile/indexを入力しても403エラーが出て表示されないことを確認
## 考慮してほしい事
- Policyが未実装のため次のタスクで行います
## 確認してほしい事
- 管理者(admin)と一般ユーザー(user)でそれぞれログインしてユーザー一覧画面の表示の制限のご確認をよろしくお願いいたします。
