### PR TITLE
#28 動作の制限(Policy)2024.3.4

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -70,6 +70,7 @@ class PostController extends Controller
      */
     public function edit(Post $post)
     {
+      $this->authorize('update',$post);
       return view('post.edit',['post' => $post]);
     }
 
@@ -78,6 +79,7 @@ class PostController extends Controller
      */
     public function update(Request $request, Post $post)
     {
+       $this->authorize('update',$post);
        $inputs = $request->validate([
           'title' => 'required|max:255',
           'body' => 'required|max:2000',
@@ -101,6 +103,7 @@ class PostController extends Controller
      */
     public function destroy(Post $post)
     {
+      $this->authorize('delete',$post);
       $post->delete();
       $post->comments()->delete();
       return redirect()->route('post.index')->with('message','投稿を削除しました');

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class PostPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Post $post): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Post $post): bool
+    {
+       return $user->id == $post->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Post $post): bool
+    {
+       if($user->id == $post->user_id) {
+        return true;
+       }
+       foreach($user->roles as $role) {
+        if($role->name == 'admin')
+         return true;
+       }
+       return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Post $post): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Post $post): bool
+    {
+        //
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,7 +1,8 @@
 <?php
 
 namespace App\Providers;
-
+use App\Models\Post; //追加
+use App\Policies\PostPolicy; //追加
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
@@ -13,7 +14,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        //
+      Post::class => PostPolicy::class,
     ];
 
     /**

--- a/resources/views/post/show.blade.php
+++ b/resources/views/post/show.blade.php
@@ -16,24 +16,25 @@
       <div class="name-display-container">
        <p> {{ $post->user->name }}さん • {{$post->created_at->diffForHumans()}}</p>
       </div>
-     @if(Auth::id() === $post->user_id)
         <div class="button-comprehensive">
-         <a href="{{ route('post.edit',$post) }}">
-          <div class="edit-button-container">
-           <button type="button" class="btn btn-success">編集</button>
-          </div>
-         </a>
-     @endif
-     @if(Auth::id() === $post->user_id)
-        <form action="{{ route('post.destroy',$post) }}" method="post">
-         @csrf
-         @method('delete')
-         <div class="edit-button-container">
-          <button type="submit" class="btn btn-danger" onClick="return confirm('本当に削除しますか？');" >削除</button>
-         </div>
-        </form>
+          {{-- ログイン本人以外または管理者は表示されない --}}
+          @can('update',$post)
+           <a href="{{ route('post.edit',$post) }}">
+            <div class="edit-button-container">
+             <button type="button" class="btn btn-success">編集</button>
+            </div>
+           </a>
+          @endcan
+          @can('delete',$post)
+           <form action="{{ route('post.destroy',$post) }}" method="post">
+            @csrf
+            @method('delete')
+             <div class="edit-button-container">
+              <button type="submit" class="btn btn-danger" onClick="return confirm('本当に削除しますか？');" >削除</button>
+             </div>
+           </form>
+          @endcan
         </div>
-     @endif
-    </div>
+  </div>
 @include('comment.show')
 @endsection


### PR DESCRIPTION
## issue
- Close #28
## 概要
- 動作の制限(Policy)の実装
## 動作確認手順
- ログインしている本人は投稿ボタン編集・削除)が正しく表示されるか確認
- 管理者(admin)の場合、自分以外のユーザーの投稿を正しく削除できる(削除ボタンの表示)が確認
- ログアウトしゲストユーザーになった場合、投稿のボタン(編集・削除)が表示されないか確認
## 考慮してほしい事
- 投稿(post)に対する返信(comment)の動作の制限がまだ未実装です
## 確認してほしい事
- それぞれのパターン(ログインユーザー・ゲストユーザー・管理者)で正しく動作の制限が行われるかご確認よろしくお願いします
