### PR TITLE
#29 動作の制限comment_policy(2024.3.4)

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -62,6 +62,7 @@ class CommentController extends Controller
      */
     public function edit(Comment $comment)
     {
+       $this->authorize('update',$comment);
        return view('comment.edit',['comment' => $comment]);
     }
 
@@ -70,6 +71,7 @@ class CommentController extends Controller
      */
     public function update(Request $request, Comment $comment)
     {
+      $this->authorize('update',$comment);
       $inputs = request()->validate([
        'body' => 'required|max:2000',
        'image' => 'image|max:2000',
@@ -91,6 +93,7 @@ class CommentController extends Controller
      */
     public function destroy(Comment $comment)
     {
+      $this->authorize('delete',$comment);
       $comment->delete();
       return redirect()->back()->with('message','コメントを削除しました');
     }

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Comment;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class CommentPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Comment $comment): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Comment $comment): bool
+    {
+       return $user->id == $comment->user_id;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Comment $comment): bool
+    {
+       if($user->id == $comment->user_id) {
+        return true;
+       }
+       foreach($user->roles as $role) {
+        if($role->name == 'admin')
+          return true;
+        }
+        return false;
+       
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Comment $comment): bool
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Comment $comment): bool
+    {
+        //
+    }
+}

--- a/resources/views/comment/show.blade.php
+++ b/resources/views/comment/show.blade.php
@@ -10,22 +10,24 @@
      <div>
         <p>{{$comment->user->name}}さん・{{$comment->created_at->diffForHumans()}}</p>
      </div>
-    @if(Auth::id() === $comment->user_id)
      <div class="button-comprehensive">
-      <a href="{{route('comment.edit',$comment)}}">
-          <div class="edit-button-container">
-            <button type="button" class="btn btn-success">コメントの編集</button>
-          </div>
-      </a>
-      <form action="{{route('comment.destroy',$comment->id)}}" method="post">
-        @csrf
-        @method('delete')
-         <div class="button-container">
-           <button type="submit" class="btn btn-danger" onClick="return-confirm('本当に削除しますか？');">コメントを削除する</button>
-         </div>
-      </form>
+      @can('update',$comment)
+        <a href="{{route('comment.edit',$comment)}}">
+            <div class="edit-button-container">
+                <button type="button" class="btn btn-success">コメントの編集</button>
+            </div>
+        </a>
+      @endcan
+      @can('delete',$comment)
+        <form action="{{route('comment.destroy',$comment->id)}}" method="post">
+            @csrf
+            @method('delete')
+            <div class="button-container">
+            <button type="submit" class="btn btn-danger" onClick="return-confirm('本当に削除しますか？');">コメントを削除する</button>
+            </div>
+        </form>
+      @endcan
     </div>
-    @endif
  </div>
 @endforeach
 {{-- コメントの機能追加 --}}


### PR DESCRIPTION
## issue
- Close #29
## 概要
- 動作の制限(comment_policy)の実装
## 動作確認手順
- 管理者ユーザー(admin)としてログインし、一般ユーザーの投稿にアクセス
- 一般ユーザーの返信コメントに削除ボタンが表示されているか確認し、正しく削除されることを確認
## 考慮してほしい事
- 管理者側のアカウントでログインして確認をお願いします
## 確認してほしい事
- 管理者としてログインした後、管理者側の制限(一般ユーザーの投稿・コメントが削除できる)が正しく行えるかご確認よろしくお願いいたします
